### PR TITLE
Fix: production servers do not return `apns-unique-id` headers

### DIFF
--- a/Apns/ApnsClient.cs
+++ b/Apns/ApnsClient.cs
@@ -54,9 +54,18 @@ public class ApnsClient: IApnsClient
 
             return ApnsResponse.Failure(error);
         }
-        
+
+        string? uniqueId;
+        try
+        {
+            uniqueId = response.Headers.GetValues(ApnsUniqueIdHeader).First();
+        }
+        catch (InvalidOperationException)
+        {
+            uniqueId = null;
+        }
+
         string id = response.Headers.GetValues(ApnsIdHeader).First();
-        string uniqueId = response.Headers.GetValues(ApnsUniqueIdHeader).First();
         var apnsGuid = new ApnsGuid(id, uniqueId);
         
         return ApnsResponse.Success(apnsGuid);

--- a/Apns/Entities/ApnsGuid.cs
+++ b/Apns/Entities/ApnsGuid.cs
@@ -1,3 +1,3 @@
 namespace Fitomad.Apns.Entities;
 
-public record ApnsGuid(string ApnsId, string ApnsUniqueId);
+public record ApnsGuid(string ApnsId, string? ApnsUniqueId);


### PR DESCRIPTION
Per Apple documentation, the production environment for APNS does not return `apns-unique-id` headers. This PR addresses this issue by ensuring that we catch this exception when parsing response data. 